### PR TITLE
Refactor BreedAdapter to be a non reflective JsonAdapter

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -15,7 +15,8 @@ java {
 tasks.withType<KotlinCompile>() {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
-        freeCompilerArgs += listOf("-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
+        freeCompilerArgs += listOf("-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi," +
+                "kotlin.ExperimentalStdlibApi")
     }
 }
 

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -15,8 +15,9 @@ java {
 tasks.withType<KotlinCompile>() {
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
-        freeCompilerArgs += listOf("-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi," +
-                "kotlin.ExperimentalStdlibApi")
+        freeCompilerArgs += listOf(
+            "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi,kotlin.ExperimentalStdlibApi"
+        )
     }
 }
 

--- a/api/src/main/java/dev/kaitei/doggo/api/adapter/BreedAdapter.kt
+++ b/api/src/main/java/dev/kaitei/doggo/api/adapter/BreedAdapter.kt
@@ -1,34 +1,66 @@
 package dev.kaitei.doggo.api.adapter
 
-import com.squareup.moshi.FromJson
-import com.squareup.moshi.ToJson
+import com.squareup.moshi.*
 import dev.kaitei.doggo.api.Breeds
 import dev.kaitei.doggo.model.Breed
 import dev.kaitei.doggo.model.SubBreed
+import java.lang.IllegalStateException
 
-class BreedAdapter {
+class BreedAdapter : JsonAdapter<Breeds>() {
 
-    @FromJson
-    fun fromJson(value: Map<String, List<String>>): Breeds =
-        value.map { (breedName, subBreedNames) ->
-            val subBreeds = subBreedNames.map { subBreedName ->
-                val id = "$breedName/$subBreedName"
-                SubBreed(
-                    id = id,
-                    name = subBreedName,
-                    parentName = breedName
-                )
+    override fun fromJson(reader: JsonReader): Breeds? {
+        return when (val token = reader.peek()) {
+
+            JsonReader.Token.BEGIN_OBJECT -> {
+                val breeds = mutableListOf<Breed>()
+                reader.beginObject()
+                while (reader.hasNext()) {
+                    val breedName = reader.nextName()
+                    val subBreeds = mutableListOf<SubBreed>()
+                    reader.beginArray()
+                    while (reader.hasNext()) {
+                        val subBreedName = reader.nextString()
+                        val id = "$breedName/$subBreedName"
+                        subBreeds += SubBreed(
+                            id = id,
+                            name = subBreedName,
+                            parentName = breedName
+                        )
+                    }
+                    reader.endArray()
+                    breeds += Breed(
+                        id = breedName,
+                        name = breedName,
+                        subs = subBreeds
+                    )
+                }
+                reader.endObject()
+                breeds.toList()
             }
-            Breed(
-                id = breedName,
-                name = breedName,
-                subs = subBreeds
+            JsonReader.Token.NULL -> {
+                null
+            }
+            else -> throw IllegalStateException(
+                "Expected BEGIN_OBJECT or NULL token, but got '$token' instead"
             )
         }
+    }
 
-    @ToJson
-    fun toJson(breeds: Breeds): Map<String, List<String>> =
-        breeds.map { breed ->
-            breed.id to breed.subs.map { subBreed -> subBreed.name }
-        }.toMap()
+    override fun toJson(writer: JsonWriter, value: Breeds?) {
+        if (value == null) {
+            writer.nullValue()
+            return
+        }
+
+        writer.beginObject()
+        value.forEach { breed ->
+            writer.name(breed.id)
+            writer.beginArray()
+            breed.subs.forEach {
+                writer.value(it.name)
+            }
+            writer.endArray()
+        }
+        writer.endObject()
+    }
 }

--- a/api/src/main/java/dev/kaitei/doggo/api/adapter/BreedAdapter.kt
+++ b/api/src/main/java/dev/kaitei/doggo/api/adapter/BreedAdapter.kt
@@ -1,6 +1,8 @@
 package dev.kaitei.doggo.api.adapter
 
-import com.squareup.moshi.*
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
 import dev.kaitei.doggo.api.Breeds
 import dev.kaitei.doggo.model.Breed
 import dev.kaitei.doggo.model.SubBreed

--- a/api/src/main/java/dev/kaitei/doggo/api/module/NetworkModule.kt
+++ b/api/src/main/java/dev/kaitei/doggo/api/module/NetworkModule.kt
@@ -3,6 +3,7 @@ package dev.kaitei.doggo.api.module
 import com.slack.eithernet.ApiResultCallAdapterFactory
 import com.slack.eithernet.ApiResultConverterFactory
 import com.squareup.moshi.Moshi
+import com.squareup.moshi.addAdapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Lazy
 import dagger.Module
@@ -21,7 +22,7 @@ class NetworkModule {
     @Provides
     fun moshi(): Moshi =
         Moshi.Builder()
-            .add(BreedAdapter())
+            .addAdapter(BreedAdapter())
             .add(KotlinJsonAdapterFactory())
             .build()
 

--- a/api/src/test/java/dev/kaitei/doggo/api/adapter/BreedAdapterTest.kt
+++ b/api/src/test/java/dev/kaitei/doggo/api/adapter/BreedAdapterTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 class BreedAdapterTest {
 
     private val moshi = Moshi.Builder()
-        .add(BreedAdapter())
+        .addAdapter(BreedAdapter())
         .addLast(KotlinJsonAdapterFactory())
         .build()
 

--- a/api/src/test/java/dev/kaitei/doggo/api/retorift/ApiResponseConverterFactoryTest.kt
+++ b/api/src/test/java/dev/kaitei/doggo/api/retorift/ApiResponseConverterFactoryTest.kt
@@ -109,7 +109,7 @@ class ApiResponseConverterFactoryTest {
 
     private fun buildService(): DoggoApi {
         val moshi = Moshi.Builder()
-            .add(BreedAdapter())
+            .addAdapter(BreedAdapter())
             .add(KotlinJsonAdapterFactory())
             .build()
 


### PR DESCRIPTION
Rewrite BreedAdapter for Moshi using JsonAdapter, so we don't use redundant serialization to from Json to Map and from Map to Breeds. This also helps to respect the order of breeds in original Json as it could be broken by serialize to map step.